### PR TITLE
Updated readme to add `yarn install` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://moon.holdings
 `yarn` is preferable over `npm` https://yarnpkg.com/en/docs/install
 `brew install yarn`
 
-'yarn install' to install dependencies
+`yarn install` to install dependencies
 
 `yarn start`
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ https://moon.holdings
 `yarn` is preferable over `npm` https://yarnpkg.com/en/docs/install
 `brew install yarn`
 
+'yarn install' to install dependencies
+
 `yarn start`
 
 `yarn run dev`


### PR DESCRIPTION
As a rookie, I struggled to realize I needed to run `yarn install` before I could run `yarn start` or the rest of the commands. I wanted to create my first pull request to suggest adding this line to the readme while I get more familiar with the rest of the project.